### PR TITLE
Fix deprecated Google Cloud bucket URL for 1000G/known_indels resources

### DIFF
--- a/setup/resources.json
+++ b/setup/resources.json
@@ -1,11 +1,11 @@
 {
     "gsnps": {
         "filetype": "VCF",
-        "url": "https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+        "url": "https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
     },
     "indel": {
         "filetype": "VCF",
-        "url": "https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" 
+        "url": "https://storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz" 
     },
     "gnomad": {
         "filetype": "VCF",


### PR DESCRIPTION
The download script `setup/download_res.py` fails with HTTP 403 when trying to download `1000G_phase1.snps.high_confidence.hg38.vcf.gz` and `Homo_sapiens_assembly38.known_indels.vcf.gz`. 
The bucket storage.googleapis.com/genomics-public-data has been migrated and now returns 403 Forbidden for anonymous access.

- Changes: 
updated the two affected URLs in setup/resources.json to point to the new bucket:
storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/ to storage.googleapis.com/gcp-public-data--broad-references/hg38/v0/

Related to #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reference data links to newer cloud storage locations, improving access to the latest available files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->